### PR TITLE
Add option for 1U or 1.5U thumb keys

### DIFF
--- a/config/src/default.toml
+++ b/config/src/default.toml
@@ -22,6 +22,7 @@ right_side_column = { active = true, side_angle = 15 }
 
 [thumb_cluster]
 keys = 3
+key_size = "U1_5"
 curvature_angle = 15
 rotation = [-17, -29, 18.5]
 offset = [-22.1, -48, 10]

--- a/config/src/default.toml
+++ b/config/src/default.toml
@@ -22,7 +22,7 @@ right_side_column = { active = true, side_angle = 15 }
 
 [thumb_cluster]
 keys = 3
-key_size = "1.5U"
+key_size = "1.5u"
 curvature_angle = 15
 rotation = [-17, -29, 18.5]
 offset = [-22.1, -48, 10]

--- a/config/src/default.toml
+++ b/config/src/default.toml
@@ -22,7 +22,7 @@ right_side_column = { active = true, side_angle = 15 }
 
 [thumb_cluster]
 keys = 3
-key_size = "U1_5"
+key_size = "1.5U"
 curvature_angle = 15
 rotation = [-17, -29, 18.5]
 offset = [-22.1, -48, 10]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -4,6 +4,7 @@ mod columns;
 mod primitives;
 
 use std::{
+    fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
     ops::Deref,
 };
@@ -192,20 +193,20 @@ impl Show for HomeRowIndex {
 #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
 /// Size of a key.
 pub enum KeySize {
-    /// Regular square key
-    #[serde(rename = "1U")]
+    /// A 1u key.
+    #[serde(rename = "1u")]
     U1,
-    /// Larger key
+    /// A 1.5u key.
     #[default]
-    #[serde(rename = "1.5U")]
+    #[serde(rename = "1.5u")]
     U1_5,
 }
 
-impl std::fmt::Display for KeySize {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for KeySize {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            KeySize::U1 => write!(f, "1U"),
-            KeySize::U1_5 => write!(f, "1.5U"),
+            KeySize::U1 => write!(f, "1u"),
+            KeySize::U1_5 => write!(f, "1.5u"),
         }?;
         Ok(())
     }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -190,12 +190,14 @@ impl Show for HomeRowIndex {
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
-/// Size of keys (1U = regular square, 1.5U = rectangular)
+/// Size of a key.
 pub enum KeySize {
     /// Regular square key
+    #[serde(rename = "1U")]
     U1,
     /// Larger key
     #[default]
+    #[serde(rename = "1.5U")]
     U1_5,
 }
 
@@ -209,32 +211,19 @@ impl std::fmt::Display for KeySize {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(transparent)]
-/// Configuration for thumb key sizes
-pub struct ThumbKeySizeValue {
-    inner: KeySize,
-}
-
-impl Show for ThumbKeySizeValue {
+impl Show for KeySize {
     fn show(&mut self, ui: &mut Ui) -> bool {
         let mut changed = false;
         ComboBox::from_label("")
-            .selected_text(self.inner.to_string())
+            .selected_text(self.to_string())
             .show_ui(ui, |ui| {
                 for value in [KeySize::U1, KeySize::U1_5] {
                     changed |= ui
-                        .selectable_value(&mut self.inner, value, value.to_string())
+                        .selectable_value(self, value, value.to_string())
                         .changed();
                 }
             });
         changed
-    }
-}
-
-impl From<&ThumbKeySizeValue> for KeySize {
-    fn from(value: &ThumbKeySizeValue) -> Self {
-        value.inner
     }
 }
 
@@ -243,8 +232,8 @@ impl From<&ThumbKeySizeValue> for KeySize {
 pub struct ThumbCluster {
     /// The number of thumb keys.
     pub keys: Ranged<i8, 1, 6>,
-    /// Size of the thumb keys, as in 1U or 1.5U
-    pub key_size: ThumbKeySizeValue,
+    /// The size of the thumb keys.
+    pub key_size: KeySize,
     /// The thumb well curvature as an angle between two neighboring keys.
     pub curvature_angle: CurvatureAngle,
     /// The rotation of the thumb cluster in relation to the finger cluster.

--- a/gui/src/model.rs
+++ b/gui/src/model.rs
@@ -1,5 +1,6 @@
 use std::iter::once;
 
+use config::KeySize;
 use glam::{DAffine3, DMat4};
 use model::{
     matrix_pcb::{
@@ -16,7 +17,7 @@ pub use model::DisplaySettings;
 pub struct Settings {
     /// The positions of the finger keys.
     pub finger_key_positions: Vec<Mat4>,
-    /// Settings for thumb keys (size, position)
+    /// The settings for the thumb keys.
     pub thumb_key_settings: ThumbKeySettings,
     /// The positions of the interface PCBs.
     pub interface_pcb_positions: Vec<Mat4>,
@@ -31,8 +32,10 @@ pub struct Settings {
 }
 
 #[derive(Clone, Default)]
+/// The settings for the thumb keys.
 pub struct ThumbKeySettings {
-    pub key_size: config::KeySize,
+    /// The size of the thumb keys.
+    pub key_size: KeySize,
     /// The positions of the thumb keys.
     pub thumb_key_positions: Vec<Mat4>,
 }
@@ -52,7 +55,7 @@ pub fn make_settings(model: &Model, config: &config::Config) -> Settings {
         .collect();
     let thumb_key_settings = ThumbKeySettings {
         thumb_key_positions,
-        key_size: (&config.thumb_cluster.key_size).into(),
+        key_size: config.thumb_cluster.key_size,
     };
     let interface_pcb_positions =
         mirrored_positions(&model.keyboard.interface_pcb_position).to_vec();

--- a/gui/src/reload.rs
+++ b/gui/src/reload.rs
@@ -17,7 +17,7 @@ use model::{MeshSettings, Model};
 use web_time::Instant;
 
 use crate::{
-    model::{Mesh, Meshes},
+    model::{make_settings, Mesh, Meshes},
     update::{Update, Updater},
 };
 
@@ -67,10 +67,8 @@ impl ModelReloader {
         let model = Model::from_config(config);
 
         if let Some(meshes) = self.cached_meshes(config) {
-            self.updater.send_update(Update::New(
-                crate::model::make_settings(&model, config),
-                meshes,
-            ));
+            self.updater
+                .send_update(Update::New(make_settings(&model, config), meshes));
         } else {
             let cancellation_token = CancellationToken::new();
             self.cancellation_token = cancellation_token.clone();
@@ -78,9 +76,7 @@ impl ModelReloader {
             let start = Instant::now();
 
             self.updater
-                .send_update(Update::Settings(crate::model::make_settings(
-                    &model, config,
-                )));
+                .send_update(Update::Settings(make_settings(&model, config)));
 
             let cancellation_token = self.cancellation_token.clone();
             let updater = self.updater.clone();

--- a/gui/src/reload.rs
+++ b/gui/src/reload.rs
@@ -67,15 +67,20 @@ impl ModelReloader {
         let model = Model::from_config(config);
 
         if let Some(meshes) = self.cached_meshes(config) {
-            self.updater
-                .send_update(Update::New((&model).into(), meshes));
+            self.updater.send_update(Update::New(
+                crate::model::make_settings(&model, config),
+                meshes,
+            ));
         } else {
             let cancellation_token = CancellationToken::new();
             self.cancellation_token = cancellation_token.clone();
 
             let start = Instant::now();
 
-            self.updater.send_update(Update::Settings((&model).into()));
+            self.updater
+                .send_update(Update::Settings(crate::model::make_settings(
+                    &model, config,
+                )));
 
             let cancellation_token = self.cancellation_token.clone();
             let updater = self.updater.clone();

--- a/model/src/key_positions/thumb_keys.rs
+++ b/model/src/key_positions/thumb_keys.rs
@@ -57,7 +57,7 @@ impl ThumbKeys {
                 .collect()
         };
 
-        let key_size = match (&config.key_size).into() {
+        let key_size = match &config.key_size {
             config::KeySize::U1 => 1.0,
             config::KeySize::U1_5 => 1.5,
         };

--- a/model/src/key_positions/thumb_keys.rs
+++ b/model/src/key_positions/thumb_keys.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, Mul};
 
-use config::ThumbCluster;
+use config::{KeySize, ThumbCluster};
 use glam::{dvec2, dvec3, DAffine3, DQuat, DVec2, DVec3, EulerRot, Vec3Swizzles};
 
 use crate::{
@@ -58,8 +58,8 @@ impl ThumbKeys {
         };
 
         let key_size = match &config.key_size {
-            config::KeySize::U1 => 1.0,
-            config::KeySize::U1_5 => 1.5,
+            KeySize::U1 => 1.0,
+            KeySize::U1_5 => 1.5,
         };
         let key_clearance =
             (dvec2(key_distance, key_size * key_distance) + DVec2::splat(KEY_CLEARANCE)) / 2.0;

--- a/model/src/key_positions/thumb_keys.rs
+++ b/model/src/key_positions/thumb_keys.rs
@@ -57,8 +57,12 @@ impl ThumbKeys {
                 .collect()
         };
 
+        let key_size = match (&config.key_size).into() {
+            config::KeySize::U1 => 1.0,
+            config::KeySize::U1_5 => 1.5,
+        };
         let key_clearance =
-            (dvec2(key_distance, 1.5 * key_distance) + DVec2::splat(KEY_CLEARANCE)) / 2.0;
+            (dvec2(key_distance, key_size * key_distance) + DVec2::splat(KEY_CLEARANCE)) / 2.0;
 
         Self {
             inner,

--- a/viewer/src/objects/keys.rs
+++ b/viewer/src/objects/keys.rs
@@ -23,6 +23,7 @@ impl Keys {
         switch_positions: Vec<Mat4>,
         finger_key_positions: Vec<Mat4>,
         thumb_key_positions: Vec<Mat4>,
+        thumb_key_size: config::KeySize,
     ) -> Self {
         let colors = &display_settings.colors;
 
@@ -34,9 +35,13 @@ impl Keys {
             colors.keycap,
             finger_key_positions,
         );
+        let thumb_keycap_asset = match thumb_key_size {
+            config::KeySize::U1_5 => &assets.keycap_1_5u,
+            config::KeySize::U1 => &assets.keycap_1u,
+        };
         let thumb_keycaps = InstancedObject::new(
             context,
-            &assets.keycap_1_5u,
+            thumb_keycap_asset,
             colors.keycap,
             thumb_key_positions,
         );

--- a/viewer/src/objects/keys.rs
+++ b/viewer/src/objects/keys.rs
@@ -1,3 +1,4 @@
+use config::KeySize;
 use gui::DisplaySettings;
 use three_d::{Camera, Context, Light, Mat4, RenderTarget};
 
@@ -23,7 +24,7 @@ impl Keys {
         switch_positions: Vec<Mat4>,
         finger_key_positions: Vec<Mat4>,
         thumb_key_positions: Vec<Mat4>,
-        thumb_key_size: config::KeySize,
+        thumb_key_size: KeySize,
     ) -> Self {
         let colors = &display_settings.colors;
 
@@ -36,8 +37,8 @@ impl Keys {
             finger_key_positions,
         );
         let thumb_keycap_asset = match thumb_key_size {
-            config::KeySize::U1_5 => &assets.keycap_1_5u,
-            config::KeySize::U1 => &assets.keycap_1u,
+            KeySize::U1_5 => &assets.keycap_1_5u,
+            KeySize::U1 => &assets.keycap_1u,
         };
         let thumb_keycaps = InstancedObject::new(
             context,

--- a/viewer/src/scene.rs
+++ b/viewer/src/scene.rs
@@ -28,7 +28,7 @@ impl Scene {
         let switch_positions: Vec<_> = settings
             .finger_key_positions
             .iter()
-            .chain(&settings.thumb_key_positions)
+            .chain(&settings.thumb_key_settings.thumb_key_positions)
             .copied()
             .collect();
         let display_settings = &settings.display_settings;
@@ -39,7 +39,8 @@ impl Scene {
             display_settings,
             switch_positions.clone(),
             settings.finger_key_positions,
-            settings.thumb_key_positions,
+            settings.thumb_key_settings.thumb_key_positions,
+            settings.thumb_key_settings.key_size,
         );
         let interface_pcbs = InterfacePcbs::new(
             context,


### PR DESCRIPTION
This change adds the option to use 1U instead of 1.5U keys for the thumb cluster, as seen on the [Skeletyl](https://github.com/Bastardkb/Skeletyl) for example. All thumb keys are still the same size though.

Before this, no config information was passed to the model/rendering stages but now we need it to know what model to display so there's some tiny refactorings.

You could extend this even further with per-key size, which some people like on corne or Kyria boards for example.

Lmk in case of style suggestions :)